### PR TITLE
Refactor slack reformatting to use common code and approach.

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -252,9 +252,12 @@ class SlackBridge():
                     # will also filter to only the GROUPME_TWO_WAY channels
                     # within the send_to_groupme call.
                     if GROUPME_ENABLE:
+                        groupme_message_text = msg + formatted_files['plaintext']
+
                         groupme_message_text = \
                             await slack_reformat.format_attachments_for_groupme(
-                                msg, attachments, edit or delete, self.user_formatter)
+                                groupme_message_text, attachments,
+                                edit or delete, self.user_formatter)
                         self.send_to_groupme(
                             channel_name, groupme_message_text, user=user,
                             edit=edit, delete=delete, me=me)

--- a/__init__.py
+++ b/__init__.py
@@ -231,16 +231,18 @@ class SlackBridge():
                             msg, attachments, edit or delete, self.user_formatter)
 
                     if channel_name in PUBLIC_TWO_WAY:
-                        self.send_to_zulip(channel_name, zulip_message_text, user=user,
-                                           send_public=True, slack_id=msg_id,
-                                           edit=edit, delete=delete, me=me)
+                        self.send_to_zulip(
+                            channel_name, zulip_message_text, user=user,
+                            send_public=True, slack_id=msg_id,
+                            edit=edit, delete=delete, me=me)
 
                     # If we are not sending publicly, then we are sending for
                     # logging purposes, which might be disabled.
                     if ZULIP_LOG_ENABLE:
-                        self.send_to_zulip(channel_name, zulip_message_text, user=user,
-                                           slack_id=msg_id, edit=edit,
-                                           delete=delete, me=me, private=private)
+                        self.send_to_zulip(
+                            channel_name, zulip_message_text, user=user,
+                            slack_id=msg_id, edit=edit,
+                            delete=delete, me=me, private=private)
 
                     # If groupme is enabled, then send there.  Note that this
                     # will also filter to only the GROUPME_TWO_WAY channels
@@ -249,8 +251,9 @@ class SlackBridge():
                         groupme_message_text = \
                             await slack_reformat.format_attachments_for_groupme(
                                 msg, attachments, edit or delete, self.user_formatter)
-                        self.send_to_groupme(channel_name, groupme_message_text, user=user,
-                                             edit=edit, delete=delete, me=me)
+                        self.send_to_groupme(
+                            channel_name, groupme_message_text, user=user,
+                            edit=edit, delete=delete, me=me)
 
                 elif channel['type'] == 'im':
                     _LOGGER.debug('updating user display name')

--- a/__init__.py
+++ b/__init__.py
@@ -180,9 +180,9 @@ class SlackBridge():
                 user_formatter = slack_reformat.SlackUserFormatter(
                     lambda user_id: self.get_slack_user(user_id, web_client=web_client))
                 data['text'] = await user_formatter.format_user(data['text'])
-                data['text'] = slack_reformat.format_notifications(data['text'])
-                data['text'] = slack_reformat.format_channels(data['text'])
-                data['text'] = slack_reformat.format_markdown_links(data['text'])
+                data['text'] = await slack_reformat.format_notifications(data['text'])
+                data['text'] = await slack_reformat.format_channels(data['text'])
+                data['text'] = await slack_reformat.format_markdown_links(data['text'])
 
                 if (channel['type'] == 'channel' or
                         channel['type'] == 'private-channel'):

--- a/__init__.py
+++ b/__init__.py
@@ -226,9 +226,13 @@ class SlackBridge():
             #                else:
             #                    msg += '\n' + file['permalink_public']
 
+                    formatted_files = slack_reformat.format_files_from_slack(data['files'])
+                    zulip_message_text = msg + formatted_files['markdown']
+
                     zulip_message_text = \
                         await slack_reformat.format_attachments_for_zulip(
-                            msg, attachments, edit or delete, self.user_formatter)
+                            zulip_message_text, attachments,
+                            edit or delete, self.user_formatter)
 
                     if channel_name in PUBLIC_TWO_WAY:
                         self.send_to_zulip(

--- a/slack_reformat.py
+++ b/slack_reformat.py
@@ -9,11 +9,39 @@ import traceback
 _LOGGER = logging.getLogger(__name__)
 
 # These are module-private regular expressions used by the reformatter
-_SLACK_USER_MATCH = re.compile("<@[A-Z0-9]+>")
-_SLACK_NOTIF_MATCH = re.compile("<![a-zA-Z0-9]+>")
-_SLACK_CHANNEL_MATCH = re.compile("<#[a-zA-Z0-9]+\\|[a-zA-Z0-9]+>")
-_SLACK_LINK_BARE_URL_MATCH = re.compile("<([a-zA-Z0-9]+:[^|]+)\\|\\1>")
-_SLACK_LINK_MATCH = re.compile("<([a-zA-Z0-9]+:[^|]+)\\|([^>]+)>")
+_SLACK_USER_MATCH = re.compile("<@([A-Z0-9]+)>")
+_SLACK_NOTIF_MATCH = re.compile("<!([a-zA-Z0-9]+)>")
+_SLACK_CHANNEL_MATCH = re.compile("<#[a-zA-Z0-9]+\\|([a-zA-Z0-9]+)>")
+_SLACK_LINK_BARE_URL_MATCH = re.compile("<([a-zA-Z0-9]+:[^|]+)(\\|\\1){0,1}>")
+_SLACK_LINK_MATCH = re.compile("<([a-zA-Z0-9]+:[^|]+)(?:\\|([^>]+)){0,1}>")
+
+
+def _do_transform(input_text,
+                  match_pattern, replace_func):
+    '''This method provides the basic work of finding parts of a slack message to replace with
+       alternate markdown, and then getting them replaced.  Private to this module.
+
+       Searches input_text for regex_search (compiled regex object)
+       Strips < > and prefix if specified.
+           Ex. "<@U###>" becomes U###, "<!here>" becomes "here"
+       Passes the regex match object to (async) replace_func, which returns what to replace it with.
+           Ex. for channels which match "<@C##|general>" replace_func would return '**#general**'
+
+       Returns the result of the transform.'''
+    transform_shift = 0
+    for m in match_pattern.finditer(input_text):
+        match = m.group()
+
+        old_text = input_text
+        start = m.start() + transform_shift
+
+        input_text = old_text[:start]
+        input_text += replace_func(m)
+        input_text += old_text[start + len(match):]
+
+        transform_shift = len(input_text) - len(old_text) + transform_shift
+    return input_text
+
 
 class SlackUserFormatter:
     def __init__(self, user_lookup_function, log_on_error=True):
@@ -54,38 +82,17 @@ class SlackUserFormatter:
         return input_text
 
 
-
 def format_notifications(input_text):
     '''Handles reformatting of things like @here.  Note that this assumes that
        any groups have already been filtered out, as they use a similar format
        but would need the ID to be looked up.'''
-    notif_shift = 0
-    for m in _SLACK_NOTIF_MATCH.finditer(input_text):
-        match = m.group()
-        notif = match[2:-1]
-        old_text = input_text
-        start = m.start() + notif_shift
-        input_text = old_text[:start]
-        input_text += '**@' + notif + '**'
-        input_text += old_text[start + len(match):]
-        notif_shift = len(input_text) - len(old_text) + notif_shift
-    return input_text
+    return _do_transform(input_text, _SLACK_NOTIF_MATCH, lambda m: ('**@%s**' % m.group(1)))
 
 
 def format_channels(input_text):
     '''Finds anything that looks like a slack channel in the text, and replaces
        it with a bolded version.  Returns the new text.'''
-    channel_shift = 0
-    for m in _SLACK_CHANNEL_MATCH.finditer(input_text):
-        match = m.group()
-        ref_channel = (match[2:-1].split('|'))[1]
-        old_text = input_text
-        start = m.start() + channel_shift
-        input_text = old_text[:start]
-        input_text += '**#' + ref_channel + '**'
-        input_text += old_text[start + len(match):]
-        channel_shift = len(input_text) - len(old_text) + channel_shift
-    return input_text
+    return _do_transform(input_text, _SLACK_CHANNEL_MATCH, lambda m: ('**#%s**' % m.group(1)))
 
 
 def format_markdown_links(input_text):
@@ -102,10 +109,8 @@ def format_markdown_links(input_text):
        <http://foo.com>
 
        Returns the new text.'''
-    link_shift = 0
-    for m in _SLACK_LINK_MATCH.finditer(input_text):
+    def replace_markdown_link(m):
         match = m.group()
-
         bare_url_match = _SLACK_LINK_BARE_URL_MATCH.match(match)
 
         if bare_url_match:
@@ -115,10 +120,6 @@ def format_markdown_links(input_text):
             replacement_displaytext = m.group(2)
             replacement = '[%s](%s)' % (replacement_displaytext, replacement_url)
 
-        old_text = input_text
-        start = m.start() + link_shift
-        input_text = old_text[:start]
-        input_text += replacement
-        input_text += old_text[start + len(match):]
-        link_shift = len(input_text) - len(old_text) + link_shift
-    return input_text
+        return replacement
+
+    return _do_transform(input_text, _SLACK_LINK_MATCH, replace_markdown_link)

--- a/slack_reformat.py
+++ b/slack_reformat.py
@@ -150,6 +150,23 @@ async def format_markdown_links(input_text):
                                _SLACK_LINK_MATCH,
                                replace_markdown_link)
 
+
+def format_files_from_slack(files=[]):
+    '''Given a list of files from the slack API, return both a markdown and plaintext
+       string representation of those files.'''
+    # TODO: This function should ideally interface with a CDN and actually move the files to a
+    # public location.  For now, we just avoid hiding the presense of a file in the message.
+    output = { 'markdown': '',
+               'plaintext': '' }
+
+    for file in files:
+        if file['name']:
+            output['markdown'] += f"\n*(Bridged Message included file: {file['name']})*"
+            output['plaintext'] += f"\n(Bridged Message included file: {file['name']})"
+
+    return output
+
+
 async def format_attachments_for_zulip(message_text, attachments, edit_or_delete, user_formatter):
     '''Translate a slack-style attachments list into text to be appended to a zulip message &
        append it to message_text, returning the result.'''

--- a/slack_reformat_test.py
+++ b/slack_reformat_test.py
@@ -3,6 +3,9 @@ import unittest
 
 import slack_reformat
 
+# Shorthand for doing an await in a unittest.
+do_await = asyncio.get_event_loop().run_until_complete
+
 class TestSlackReformat(unittest.TestCase):
     def test_format_user(self):
         # Simple standin for the redis lookup.
@@ -17,9 +20,6 @@ class TestSlackReformat(unittest.TestCase):
                 return False
 
         user_formatter = slack_reformat.SlackUserFormatter(user_lookup, log_on_error=False)
-
-        # Shorthand for doing an await in a unittest.
-        do_await = asyncio.get_event_loop().run_until_complete
 
         # Null Case
         self.assertEqual(
@@ -61,19 +61,19 @@ class TestSlackReformat(unittest.TestCase):
     def test_format_notifications(self):
         # No groups in text
         self.assertEqual(
-            slack_reformat.format_notifications('Plain Text'),
+            do_await(slack_reformat.format_notifications('Plain Text')),
             'Plain Text'
         )
 
         # One group in text
         self.assertEqual(
-            slack_reformat.format_notifications('Text with notification <!here> for you'),
+            do_await(slack_reformat.format_notifications('Text with notification <!here> for you')),
             'Text with notification **@here** for you'
         )
 
         # Multiple notifications
         self.assertEqual(
-            slack_reformat.format_notifications('<!here> Ping <!everyone> Loud <!channel>!'),
+            do_await(slack_reformat.format_notifications('<!here> Ping <!everyone> Loud <!channel>!')),
             '**@here** Ping **@everyone** Loud **@channel**!'
         )
 
@@ -81,26 +81,28 @@ class TestSlackReformat(unittest.TestCase):
     def test_format_channels(self):
         # No channels in text
         self.assertEqual(
-            slack_reformat.format_channels('Plain Text'),
+            do_await(slack_reformat.format_channels('Plain Text')),
             'Plain Text'
         )
 
         # One channel in text
         self.assertEqual(
-            slack_reformat.format_channels('Text with <#C123G567|channel> inline'),
+            do_await(slack_reformat.format_channels('Text with <#C123G567|channel> inline')),
             'Text with **#channel** inline'
         )
 
         # Two channels in text
         self.assertEqual(
-            slack_reformat.format_channels('<#C1234567|channel1> with another <#C123AD67|channel2> etc'),
+            do_await(slack_reformat.format_channels(
+                '<#C1234567|channel1> with another <#C123AD67|channel2> etc')),
             '**#channel1** with another **#channel2** etc'
         )
 
         # Three channels
 
         self.assertEqual(
-            slack_reformat.format_channels('<#C1234567|channel1> <#C12BB567|channel2> <#C12AA567|channel3>!'),
+            do_await(slack_reformat.format_channels(
+                '<#C1234567|channel1> <#C12BB567|channel2> <#C12AA567|channel3>!')),
             '**#channel1** **#channel2** **#channel3**!'
         )
 
@@ -108,49 +110,51 @@ class TestSlackReformat(unittest.TestCase):
     def test_markdown_links(self):
         # Does nothing if it shouldn't
         self.assertEqual(
-            slack_reformat.format_markdown_links('Plain Text'),
+            do_await(slack_reformat.format_markdown_links('Plain Text')),
             'Plain Text'
         )
 
         # Does nothing if there is a bare URL there
         self.assertEqual(
-            slack_reformat.format_markdown_links('http://foo.com'),
+            do_await(slack_reformat.format_markdown_links('http://foo.com')),
             'http://foo.com'
         )
 
         # Base case - just the URL without a piped display name just gets its brackets stripped.
         self.assertEqual(
-            slack_reformat.format_markdown_links('<http://foo.com>'),
+            do_await(slack_reformat.format_markdown_links('<http://foo.com>')),
             'http://foo.com'
         )
 
         # Base case - just the URL with a duplicated display name
         self.assertEqual(
-            slack_reformat.format_markdown_links('<http://foo.com|http://foo.com>'),
+            do_await(slack_reformat.format_markdown_links('<http://foo.com|http://foo.com>')),
             'http://foo.com'
         )
 
         # Base case - URL with display text
         self.assertEqual(
-            slack_reformat.format_markdown_links('<http://foo.com|Display Text>'),
+            do_await(slack_reformat.format_markdown_links('<http://foo.com|Display Text>')),
             '[Display Text](http://foo.com)'
         )
 
         # One of each
         self.assertEqual(
-            slack_reformat.format_markdown_links('Text <http://foo.com|http://foo.com> And <http://foo.com|Display Text> Done'),
+            do_await(slack_reformat.format_markdown_links(
+                'Text <http://foo.com|http://foo.com> And <http://foo.com|Display Text> Done')),
             'Text http://foo.com And [Display Text](http://foo.com) Done'
         )
 
         # Three replacements
         self.assertEqual(
-            slack_reformat.format_markdown_links('Text <http://foo.com|http://foo.com> And <http://foo.com|Display Text> <http://bar.com|http://bar.com> Done'),
+            do_await(slack_reformat.format_markdown_links(
+                'Text <http://foo.com|http://foo.com> And <http://foo.com|Display Text> <http://bar.com|http://bar.com> Done')),
             'Text http://foo.com And [Display Text](http://foo.com) http://bar.com Done'
         )
 
         # mailto: scheme works (i.e. leading // isn't required)
         self.assertEqual(
-            slack_reformat.format_markdown_links('<mailto:x@x.com|mailto:x@x.com>'),
+            do_await(slack_reformat.format_markdown_links('<mailto:x@x.com|mailto:x@x.com>')),
             'mailto:x@x.com'
         )
 

--- a/slack_reformat_test.py
+++ b/slack_reformat_test.py
@@ -118,13 +118,13 @@ class TestSlackReformat(unittest.TestCase):
             'http://foo.com'
         )
 
-        # Does nothing if there is a bare URL there, even in brackets
+        # Base case - just the URL without a piped display name just gets its brackets stripped.
         self.assertEqual(
             slack_reformat.format_markdown_links('<http://foo.com>'),
-            '<http://foo.com>'
+            'http://foo.com'
         )
 
-        # Base case - just the URL
+        # Base case - just the URL with a duplicated display name
         self.assertEqual(
             slack_reformat.format_markdown_links('<http://foo.com|http://foo.com>'),
             'http://foo.com'

--- a/slack_reformat_test.py
+++ b/slack_reformat_test.py
@@ -1,8 +1,63 @@
+import asyncio
 import unittest
 
 import slack_reformat
 
 class TestSlackReformat(unittest.TestCase):
+    def test_format_user(self):
+        # Simple standin for the redis lookup.
+        async def user_lookup(id):
+            if id == '12345':
+                return 'Alice'
+            elif id == '54321':
+                return 'Bob'
+            elif id == 'ERROR':
+                raise NameError
+            else:
+                return False
+
+        user_formatter = slack_reformat.SlackUserFormatter(user_lookup, log_on_error=False)
+
+        # Shorthand for doing an await in a unittest.
+        do_await = asyncio.get_event_loop().run_until_complete
+
+        # Null Case
+        self.assertEqual(
+            do_await(user_formatter.format_user('Plain Text')),
+            'Plain Text'
+        )
+
+        # Just Alice
+        self.assertEqual(
+            do_await(user_formatter.format_user('Hi <@12345>')),
+            'Hi **@Alice**'
+        )
+
+        # Unknown user
+        self.assertEqual(
+            do_await(user_formatter.format_user('Hi <@Unknown>')),
+            'Hi <@Unknown>'
+        )
+
+        # Multiple Names
+        self.assertEqual(
+            do_await(user_formatter.format_user('Hi <@12345> and <@54321> and <@12345>!')),
+            'Hi **@Alice** and **@Bob** and **@Alice**!'
+        )
+
+        # Simple error case -- should just hand back the original
+        self.assertEqual(
+            do_await(user_formatter.format_user('Hi <@ERROR>')),
+            'Hi <@ERROR>'
+        )
+
+        # Error on second name should still convert other non-error ones.
+        self.assertEqual(
+            do_await(user_formatter.format_user('Hi <@12345> and <@ERROR> and <@54321>!')),
+            'Hi **@Alice** and <@ERROR> and **@Bob**!'
+        )
+
+
     def test_format_notifications(self):
         # No groups in text
         self.assertEqual(
@@ -21,6 +76,7 @@ class TestSlackReformat(unittest.TestCase):
             slack_reformat.format_notifications('<!here> Ping <!everyone> Loud <!channel>!'),
             '**@here** Ping **@everyone** Loud **@channel**!'
         )
+
 
     def test_format_channels(self):
         # No channels in text
@@ -47,7 +103,6 @@ class TestSlackReformat(unittest.TestCase):
             slack_reformat.format_channels('<#C1234567|channel1> <#C12BB567|channel2> <#C12AA567|channel3>!'),
             '**#channel1** **#channel2** **#channel3**!'
         )
-
 
 
     def test_markdown_links(self):

--- a/slack_reformat_test.py
+++ b/slack_reformat_test.py
@@ -176,6 +176,68 @@ class TestSlackReformat(unittest.TestCase):
             'mailto:x@x.com'
         )
 
+    def test_format_attachments_for_zulip(self):
+        # Note: This test is _not_ exhaustive!
+
+        # Base case
+        self.assertEqual(
+            do_await(slack_reformat.format_attachments_for_zulip('message', [], False, None)),
+            'message'
+        )
+
+        # Link preview attachment.
+        google_link_preview = {
+            'title': 'Google',
+            'title_link': 'http://www.google.com/',
+            'text': 'Search the world\'s information',
+            'fallback': 'Google',
+            'from_url': 'http://www.google.com/',
+            'service_icon': 'http://www.google.com/favicon.ico',
+            'service_name': 'google.com',
+            'id': 1,
+            'original_url': 'http://www.google.com'
+        }
+        self.assertEqual(
+            do_await(slack_reformat.format_attachments_for_zulip(
+                'message', [google_link_preview], False, None)),
+            'message\n\n```quote\n**[Google](http://www.google.com/)**\nSearch the world\'s information\n```'
+        )
+
+        # Github app attachment
+        github_app_attachment = {
+            "fallback": "ABTech/zulip_slack_integration",
+            "title": "ABTech/zulip_slack_integration",
+            "footer": "<https://github.com/ABTech/zulip_slack_integration|ABTech/zulip_slack_integration>",
+            "id": 1,
+            "footer_icon": "https://github.githubassets.com/favicon.ico",
+            "ts": 1558647312,
+            "color": "24292f",
+            "fields": [{
+                    "title": "Stars",
+                    "value": "1",
+                    "short": True
+                }, {
+                    "title": "Language",
+                    "value": "Python",
+                    "short": True
+                }],
+            "mrkdwn_in": ["text", "fields"],
+            "bot_id": "BSWPYJGUF",
+            "app_unfurl_url": "https://github.com/ABTech/zulip_slack_integration",
+            "is_app_unfurl": True
+        }
+        self.assertEqual(
+            do_await(slack_reformat.format_attachments_for_zulip(
+                'message', [github_app_attachment], False, None)),
+            'message\n\n```quote\n**ABTech/zulip_slack_integration**\n**Stars**\n1\n**Language**\nPython\n*<https://github.com/ABTech/zulip_slack_integration|ABTech/zulip_slack_integration>* | *Thu May 23 14:35:12 2019*\n```'
+            )
+
+    def test_format_attachments_for_groupme(self):
+        # This test is just a placeholder since the function called is a placeholder.
+        self.assertEqual(
+            do_await(slack_reformat.format_attachments_for_groupme('message', [], False, None)),
+            'message'
+        )
 
 if __name__ == '__main__':
     unittest.main()

--- a/slack_reformat_test.py
+++ b/slack_reformat_test.py
@@ -176,6 +176,42 @@ class TestSlackReformat(unittest.TestCase):
             'mailto:x@x.com'
         )
 
+    def test_format_files_from_slack(self):
+        # Note: This test is _not_ exhaustive!
+
+        # Base case
+        output = slack_reformat.format_files_from_slack([])
+        self.assertEqual(output['plaintext'], '')
+        self.assertEqual(output['markdown'], '')
+
+        # Single file
+        test_file = {
+            "id": "U0000000",
+            "created": 1579621511,
+            "timestamp": 1579621511,
+            "name": "filename.jpg",
+            "title": "filename.jpg",
+            "mimetype": "image/jpeg",
+            "filetype": "jpg",
+            "pretty_type": "JPEG",
+            "user": "U1111111",
+            "editable": False,
+            "size": 750000,
+            "mode": "hosted",
+            "is_external": False,
+            "external_type": "",
+            "is_public": False,
+            "public_url_shared": False,
+            "display_as_bot": False,
+            "username": "",
+            "url_private": "https://files.slack.com/files-pri/T0000000-F0000000/filename.jpg"
+            # ... and many omitted fields
+        }
+        output = slack_reformat.format_files_from_slack([test_file])
+        self.assertEqual(output['plaintext'], '\n(Bridged Message included file: filename.jpg)')
+        self.assertEqual(output['markdown'], '\n*(Bridged Message included file: filename.jpg)*')
+
+
     def test_format_attachments_for_zulip(self):
         # Note: This test is _not_ exhaustive!
 

--- a/slack_reformat_test.py
+++ b/slack_reformat_test.py
@@ -7,6 +7,24 @@ import slack_reformat
 do_await = asyncio.get_event_loop().run_until_complete
 
 class TestSlackReformat(unittest.TestCase):
+    def test_reformat_slack_text(self):
+        # Simple standin for the redis lookup.
+        async def user_lookup(id):
+            if id == '12345':
+                return 'Alice'
+            else:
+                return False
+
+        user_formatter = slack_reformat.SlackUserFormatter(user_lookup, log_on_error=False)
+
+        # Just check one of everything to make sure it all works.
+        self.assertEqual(
+            do_await(
+                slack_reformat.reformat_slack_text(user_formatter,
+                    'User <@12345> Channel <#C123G567|channel> Notif <!here> Link <http://foo.com>')),
+            'User **@Alice** Channel **#channel** Notif **@here** Link http://foo.com')
+
+
     def test_format_user(self):
         # Simple standin for the redis lookup.
         async def user_lookup(id):


### PR DESCRIPTION
- Extracts user formatting to the slack_reformat module
- Refactors all the reformatters to use a common base function, _do_transform
- Requires making tons of things async so that the user formatter can use the same approach.