### PR TITLE
Formatting bugfixes

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -235,7 +235,11 @@ class SlackBridge():
                             msg, attachments,
                             edit or delete, self.user_formatter)
 
-                    formatted_files = slack_reformat.format_files_from_slack(files)
+                    # Assumes that both markdown and plaintext need a newline together.
+                    needs_leading_newline = \
+                        (len(msg) > 0 or len(formatted_attachments['markdown']) > 0)
+                    formatted_files = slack_reformat.format_files_from_slack(
+                        files, needs_leading_newline)
 
                     zulip_message_text = \
                         msg + formatted_attachments['markdown'] + formatted_files['markdown']

--- a/slack_reformat.py
+++ b/slack_reformat.py
@@ -13,8 +13,8 @@ _LOGGER = logging.getLogger(__name__)
 _SLACK_USER_MATCH = re.compile("<@([A-Z0-9]+)>")
 _SLACK_NOTIF_MATCH = re.compile("<!([a-zA-Z0-9]+)>")
 _SLACK_CHANNEL_MATCH = re.compile("<#[a-zA-Z0-9]+\\|([a-zA-Z0-9]+)>")
-_SLACK_LINK_BARE_URL_MATCH = re.compile("<([a-zA-Z0-9]+:[^|]+)(\\|\\1){0,1}>")
-_SLACK_LINK_MATCH = re.compile("<([a-zA-Z0-9]+:[^|]+)(?:\\|([^>]+)){0,1}>")
+_SLACK_LINK_BARE_URL_MATCH = re.compile("<([a-zA-Z0-9]+:[^|>]+)(\\|\\1){0,1}>")
+_SLACK_LINK_MATCH = re.compile("<([a-zA-Z0-9]+:[^|>]+)(?:\\|([^>]+)){0,1}>")
 
 async def reformat_slack_text(user_formatter, input_text):
     '''This helper method, given a SlackUserFormatter, will format the input_text

--- a/slack_reformat.py
+++ b/slack_reformat.py
@@ -151,9 +151,12 @@ async def format_markdown_links(input_text):
                                replace_markdown_link)
 
 
-def format_files_from_slack(files):
+def format_files_from_slack(files, needs_leading_newline):
     '''Given a list of files from the slack API, return both a markdown and plaintext
-       string representation of those files.'''
+       string representation of those files.
+
+       This method only uses the passed in message text to determine how to format its output
+       caller must append as appropriate.'''
     if files == None:
         files = []
 
@@ -162,10 +165,17 @@ def format_files_from_slack(files):
     output = { 'markdown': '',
                'plaintext': '' }
 
+    first_file = True
     for file in files:
+        if not first_file or needs_leading_newline:
+            output['markdown'] += '\n'
+            output['plaintext'] += '\n'
+        else:
+            first_file = False
+
         if 'name' in file and file['name']:
-            output['markdown'] += f"\n*(Bridged Message included file: {file['name']}"
-            output['plaintext'] += f"\n(Bridged Message included file: {file['name']}"
+            output['markdown'] += f"*(Bridged Message included file: {file['name']}"
+            output['plaintext'] += f"(Bridged Message included file: {file['name']}"
             if 'title' in file and file['title'] and file['name'] != file['title']:
                 output['markdown'] += f": '{file['title']}'"
                 output['plaintext'] += f": '{file['title']}'"

--- a/slack_reformat_test.py
+++ b/slack_reformat_test.py
@@ -171,6 +171,21 @@ class TestSlackReformat(unittest.TestCase):
             'Text http://foo.com And [Display Text](http://foo.com) http://bar.com Done'
         )
 
+        # Two bare link replacements
+        self.assertEqual(
+            do_await(slack_reformat.format_markdown_links(
+                'Test <http://foo.com> <http://google.com>')),
+            'Test http://foo.com http://google.com'
+        )
+
+        # Multiple Links: Bare & Display Name & Display Name == Link
+        self.assertEqual(
+            do_await(slack_reformat.format_markdown_links(
+                'Test <http://foo.com> <http://google.com|The Goog> <http://bar.com|http://bar.com>')),
+            'Test http://foo.com [The Goog](http://google.com) http://bar.com'
+        )
+
+
         # mailto: scheme works (i.e. leading // isn't required)
         self.assertEqual(
             do_await(slack_reformat.format_markdown_links('<mailto:x@x.com|mailto:x@x.com>')),


### PR DESCRIPTION
- Fix an issue with translating multiple links, especially when they are bare links.
- Be more careful about adding newlines to file-upload messages.