### PR TITLE
Update slack client to 2.5.0 from the git-frozen version.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 redis==3.2.1
 requests==2.22.0
-git+git://github.com/slackapi/python-slackclient@66017f39adfbe6d0c38cb1f0d6e551aff949398c#egg=slackclient
+slackclient==2.5.0
 zulip==0.6.0


### PR DESCRIPTION
Solves Issue #3.  Tested and seems to work as good as current frozen version.